### PR TITLE
fix(hardening/seccomp): change "reject" to "allow"

### DIFF
--- a/source/hardening/seccomp.md
+++ b/source/hardening/seccomp.md
@@ -5,7 +5,7 @@ AppArmor と同様に seccomp プロファイルもコンテナ上で動作す�
 
 AppArmor のときと同様に実行すると `home/ubuntu/dist_linux/.docker-slim-state/images/9140108b62dc87d9bb278bb0d4fd6a3e44c2959646eb966b86531306faa81b09b/artifacts/ubuntu-seccomp.json` に seccomp プロファイルが生成されます。
 
-生成された seccomp プロファイルを見ると、禁止されるシステムコールが明示的に記述されていることが確認できます。
+生成された seccomp プロファイルを見ると、許可されるシステムコールが明示的に記述されていることが確認できます。
 
 ```json
 {


### PR DESCRIPTION
defaultActionがSCMP_ACT_ERRNOで各syscallsのactionがSCMP_ACT_ALLOWなので、許可されるシステムコールが明示的に記述されている、が正しいかと思ったのですがいかがでしょうか？
何か見落としていて間違っていたらすみません。